### PR TITLE
docs: add health check endpoint wiki page

### DIFF
--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -1,0 +1,124 @@
+# /document — Create or update wiki documentation
+
+## Description
+
+Creates or updates a wiki documentation page for a feature, service, or process in the Pensieve codebase.
+
+## Usage
+
+```
+/document <feature or process name>
+```
+
+Example: `/document memory ingestion pipeline`
+
+## Instructions
+
+You are creating or updating wiki documentation. Follow these steps:
+
+### 1. Understand the topic
+
+Read the user's topic from `$ARGUMENTS`. The topic is a feature, service, process, or architectural concept in the Pensieve codebase.
+
+### 2. Explore the codebase
+
+Use Read, Grep, and Glob to find all relevant code:
+- Services in `packages/server/src/services/`
+- Handlers in `packages/server/src/handlers/`
+- Types in `packages/types/`
+- Database schema in `packages/server/src/db/schema/`
+- Tests for understanding behavior
+- Existing orchestrators and entry points
+
+Build a complete picture of the feature: what files are involved, how data flows, what the public API looks like.
+
+### 3. Check existing docs
+
+Read all files in `docs/wiki/` to:
+- Avoid creating a duplicate page for something already documented
+- Find related pages to cross-reference
+- If a page for this topic already exists, update it instead of creating a new one
+
+### 4. Generate the documentation page
+
+Create a markdown file with this exact structure:
+
+```markdown
+---
+title: <Page Title>
+description: <One-line description>
+sources:
+  - <path/to/source-file-1.ts>
+  - <path/to/source-file-2.ts>
+---
+
+# <Page Title>
+
+## Overview
+
+<2-3 paragraphs explaining what this feature/process does, why it exists, and how it fits into the larger system.>
+
+## Flow
+
+<Mermaid diagram showing the process flow, data flow, or architecture. Use the appropriate diagram type:>
+- `graph TD` for process/data flows
+- `sequenceDiagram` for interactions between components
+- `classDiagram` for type relationships (use as structure diagram, not OOP)
+
+## Components
+
+### <Component Name>
+
+[`functionName`](https://github.com/ilarinie/pensieve/blob/main/path/to/file.ts)
+
+<Description of what this component does, its parameters, and its role in the feature.>
+
+### <Next Component>
+
+...
+
+## Related Pages
+
+- [Related Page](related-page) — brief description of relationship
+```
+
+### 5. Frontmatter rules
+
+The `sources` list in frontmatter is critical — it drives staleness detection during PR reviews:
+- List every source file that this documentation page describes
+- Use repo-relative paths (e.g., `packages/server/src/services/memory/store-memory.ts`)
+- Include service files, handler files, type files, and schema files
+- Do NOT include test files in sources
+
+### 6. File naming
+
+- Use kebab-case: `memory-ingestion-pipeline.md`, `health-check-endpoint.md`
+- The file name should match the page title (slugified)
+- Write to `docs/wiki/<page-slug>.md`
+
+### 7. Update the sidebar
+
+After writing the page, update `docs/wiki/_Sidebar.md`:
+- Add the new page to the navigation list
+- Keep pages in alphabetical order (after Home)
+- Use wiki-style links: `[Page Title](page-slug)`
+
+### 8. Report to user
+
+Tell the user:
+- The file path of the created/updated page
+- A summary of what was documented
+- Which source files are tracked in `sources`
+- Suggest reviewing the page before committing
+
+## Allowed tools
+
+Read, Grep, Glob, Write
+
+## Important
+
+- Do NOT commit, push, or run git commands — the user handles that
+- Do NOT modify any source code — only create/update documentation
+- Always include Mermaid diagrams — they are a key part of every doc page
+- Always include source links using `https://github.com/ilarinie/pensieve/blob/main/...` URLs
+- Keep the writing concise and technical — this is developer documentation, not a tutorial

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,5 +31,14 @@ jobs:
             - const + arrow for exports
             - type not interface
             - kebab-case file names
+
+            Documentation check:
+            - Read docs/wiki/*.md files and their frontmatter `sources:` lists
+            - If any file in the PR diff appears in a doc page's `sources:`, flag that
+              the documentation may need updating and name the specific wiki page(s)
+            - If new service files, handlers, or significant features are added
+              (e.g. new files in packages/server/src/services/ or packages/server/src/handlers/)
+              and no docs/wiki/ page lists them in its sources, suggest creating documentation
+
             Post inline comments for specific issues.
             Approve if the PR follows all rules, request changes otherwise.

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,28 @@
+name: Wiki Sync
+on:
+  push:
+    branches: [main]
+    paths: ['docs/wiki/**']
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone wiki repo
+        run: |
+          git clone https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git wiki-repo
+
+      - name: Sync wiki content
+        run: |
+          cp docs/wiki/*.md wiki-repo/
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "sync wiki from main ($(git -C .. rev-parse --short HEAD))"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,16 @@ All validated at startup via Zod in `env.ts`. App crashes immediately on missing
 - Use `type` not `interface` (functional style)
 - Prefer Zod schemas with `z.infer<typeof schema>` for runtime-validated types
 
+## Documentation
+
+Wiki documentation lives in `docs/wiki/` and syncs to the GitHub Wiki on merge to main.
+
+- `/document <feature>` — create or update a wiki page
+- Every doc page has YAML frontmatter with `sources:` listing the files it documents
+- PR reviews check for doc staleness (changed source files → flagged wiki pages)
+- Mermaid diagrams for process flows and architecture
+- Code links use `/blob/main/...` URLs to the source files
+
 ## Planning Workflow
 
 1. `/plan <description>` — create structured plan in `docs/plans/`

--- a/docs/github-automation.md
+++ b/docs/github-automation.md
@@ -29,6 +29,9 @@
 | `priority:high` | Important |
 | `priority:medium` | Normal priority |
 | `priority:low` | Nice to have |
+| `layer:0` | Independent, parallelizable work item |
+| `layer:1` | Depends on layer 0 items |
+| `layer:2` | Orchestrator, depends on layer 1 items |
 
 ### GitHub Actions (`.github/workflows/`)
 
@@ -40,6 +43,16 @@ Four Claude Code workflows run on GitHub runners:
 | Implementation | `claude-implement.yml` | `@claude` comment or `claude:implement` label |
 | Issue Triage | `claude-triage.yml` | New issue opened |
 | Weekly Maintenance | `claude-maintenance.yml` | Monday 10:00 Helsinki (cron) or manual dispatch |
+
+### Claude Code Skills (`.claude/skills/`)
+
+Three skills for the planning → issues → implementation workflow:
+
+| Skill | File | Purpose |
+|-------|------|---------|
+| `/plan` | `plan/SKILL.md` | Explore codebase, write structured plan file |
+| `/create-issues` | `create-issues/SKILL.md` | Parse plan file, create GitHub issues with dependencies |
+| `/implement` | `implement/SKILL.md` | Local TDD implementation of a single issue |
 
 ### GitHub MCP Server (local Claude Code)
 
@@ -53,6 +66,17 @@ env var and Docker running.
 - `.github/ISSUE_TEMPLATE/bug.md` — bug report template
 - `.github/pull_request_template.md` — PR checklist (tests, types, lint, format, TSDoc)
 
+### GitHub Resource IDs
+
+Used by `/create-issues` skill for GraphQL API calls:
+
+| Resource | Node ID |
+|----------|---------|
+| Repo | `R_kgDORUITUg` |
+| Project | `PVT_kwHOAHTkk84BPpUQ` |
+| Status field | `PVTSSF_lAHOAHTkk84BPpUQzg9_rzQ` |
+| "Todo" option | `2eec6910` |
+
 ---
 
 ## Secrets & Tokens
@@ -64,7 +88,51 @@ env var and Docker running.
 
 ---
 
-## How to Use
+## Day-to-Day Workflow
+
+### Planned work (features, phases)
+
+The primary workflow for non-trivial work uses the three skills:
+
+```
+1. /plan "Phase 3 - Cron scheduler"
+   → Claude explores codebase, writes docs/plans/phase-3-cron-scheduler.md
+
+2. Review/edit the plan file
+
+3. /create-issues docs/plans/phase-3-cron-scheduler.md
+   → Parent issue + sub-issues created with blocked-by relationships
+   → All added to project board in "Todo"
+
+4. /implement 42  (local, interactive)
+     — OR —
+   Add "claude:implement" label  (remote, async via GitHub Action)
+   → Branch created, TDD implementation, PR opened
+
+5. PR opened → auto-reviewed by Claude
+   → Board moves to In Review
+
+6. Merge PR
+   → Issue auto-closes → board moves to Done → parent shows progress
+```
+
+### Ad-hoc work (bugs, small tasks)
+
+For one-off issues that don't need a plan:
+
+```
+1. Create issue (GitHub UI or Claude Code + MCP)
+   → Auto-triaged, labeled, added to board Backlog
+
+2. Implement:
+   a. /implement <number>  (local)
+   b. Comment "@claude implement this"  (remote)
+   c. Add "claude:implement" label  (remote)
+
+3. PR opened → auto-reviewed by Claude
+
+4. Merge → issue auto-closes → board moves to Done
+```
 
 ### From the terminal (Claude Code + MCP)
 
@@ -81,121 +149,21 @@ With the GitHub MCP server running, Claude Code can interact with GitHub directl
 → Opens a PR on GitHub
 ```
 
-### Issue-driven implementation
-
-**Option A — `@claude` mention:**
-
-1. Create an issue with a description of what to build
-2. Comment `@claude implement this`
-3. Claude reads CLAUDE.md, scans the codebase, creates a branch, implements, opens a PR
-4. Review the PR — request changes with `@claude fix X`
-5. Merge → issue auto-closes → board moves to Done
-
-**Option B — label trigger:**
-
-1. Create an issue
-2. Add the `claude:implement` label
-3. Same result — Claude implements and opens a PR
-
-### Automatic PR review
-
-Every PR gets an automatic Claude review checking:
-
-- Functional style (no classes)
-- Dependency injection (db as first param)
-- TSDoc on every export
-- Test coverage
-- Security (OWASP top 10)
-- Code style (no semicolons, single quotes, `.js` imports, `type` not `interface`)
-
-The review posts inline comments and approves or requests changes.
-
-### Automatic issue triage
-
-Every new issue is automatically analyzed by Claude:
-
-- Categorized as bug/feature/question/chore
-- Priority assessed (critical/high/medium/low)
-- Labels applied
-- Duplicate check performed
-
-### Weekly maintenance
-
-Runs every Monday at 10:00 Helsinki (8:00 UTC). Can also be triggered manually
-from Actions → Weekly Maintenance → Run workflow.
-
-Checks:
-- Outdated dependencies
-- Security vulnerabilities (npm audit)
-- Stale issues (>30 days)
-- TODO/FIXME comments
-- Missing tests
-
-Creates a summary issue with findings.
-
 ---
 
-## Day-to-Day Workflow
+## Layer System
 
-```
-1. Create issue (GitHub UI or Claude Code + MCP)
-   → Auto-triaged, labeled, added to board Backlog
+Plans decompose features into layered work items for parallel implementation:
 
-2. Move to Todo when ready to plan
+| Layer | Label | Meaning | Examples |
+|-------|-------|---------|----------|
+| L0 | `layer:0` | No deps on other new items — parallelizable | Types, standalone services, utilities |
+| L1 | `layer:1` | Depends on L0 items | Services using L0 types, endpoints |
+| L2 | `layer:2` | Orchestrators wiring L0+L1 together | Handlers, integration points |
 
-3. Implement:
-   a. Self: create branch, code, push, open PR
-   b. Claude: comment "@claude implement this" or add "claude:implement" label
-
-4. PR opened → auto-reviewed by Claude
-   → Board moves to In Review
-
-5. Fix review comments, merge
-   → Issue auto-closes, board moves to Done
-```
-
----
-
-## Planning Workflow
-
-Structured workflow connecting planning → issue creation → parallel implementation.
-
-### Skills
-
-| Skill | Purpose |
-|-------|---------|
-| `/plan <description>` | Explore codebase, create structured plan in `docs/plans/` |
-| `/create-issues <plan-file>` | Parse plan file, create parent + sub-issues with dependencies |
-| `/implement <issue-number>` | Local TDD implementation of a single issue |
-
-### Layer System
-
-Plans decompose work into layers for parallelism:
-
-| Layer | Label | Meaning |
-|-------|-------|---------|
-| L0 | `layer:0` | Independent, no deps on new items — parallelizable |
-| L1 | `layer:1` | Depends on L0 items |
-| L2 | `layer:2` | Orchestrators wiring L0+L1 together |
-
-### Full Flow
-
-```
-/plan "Phase 3 - Cron scheduler"
-  → Claude explores codebase, writes docs/plans/phase-3-cron-scheduler.md
-  → User reviews/edits the plan file
-
-/create-issues docs/plans/phase-3-cron-scheduler.md
-  → Creates parent issue + sub-issues with blocked-by relationships
-  → All added to project board in "Todo"
-
-/implement 42  (local, interactive)
-  — OR —
-Add "claude:implement" label  (remote, async via GitHub Action)
-  → Branch created, TDD implementation, PR opened
-
-PR merged → issue auto-closes → board moves to Done
-```
+Each work item = one sub-issue = one branch = one PR. All L0 items can be
+implemented in parallel. L1 items start after their L0 dependencies merge.
+L2 items start last.
 
 ### Plan File Format
 
@@ -234,14 +202,113 @@ Parse and validate cron schedule configurations.
 ...
 ```
 
-### GitHub Resources
+---
 
-| Resource | Node ID |
-|----------|---------|
-| Repo | `R_kgDORUITUg` |
-| Project | `PVT_kwHOAHTkk84BPpUQ` |
-| Status field | `PVTSSF_lAHOAHTkk84BPpUQzg9_rzQ` |
-| "Todo" option | `2eec6910` |
+## Automatic Workflows
+
+### PR review
+
+Every PR gets an automatic Claude review checking:
+
+- Functional style (no classes)
+- Dependency injection (db as first param)
+- TSDoc on every export
+- Test coverage
+- Security (OWASP top 10)
+- Code style (no semicolons, single quotes, `.js` imports, `type` not `interface`)
+
+The review posts inline comments and approves or requests changes.
+
+### Issue triage
+
+Every new issue is automatically analyzed by Claude:
+
+- Categorized as bug/feature/question/chore
+- Priority assessed (critical/high/medium/low)
+- Labels applied
+- Duplicate check performed
+
+### Weekly maintenance
+
+Runs every Monday at 10:00 Helsinki (8:00 UTC). Can also be triggered manually
+from Actions → Weekly Maintenance → Run workflow.
+
+Checks:
+- Outdated dependencies
+- Security vulnerabilities (npm audit)
+- Stale issues (>30 days)
+- TODO/FIXME comments
+- Missing tests
+
+Creates a summary issue with findings.
+
+---
+
+## Wiki Documentation
+
+### Overview
+
+Documentation source lives in `docs/wiki/` in the main repo. A GitHub Action syncs
+content to the GitHub Wiki on merge to main. Mermaid diagrams render natively in both
+the repo and wiki views.
+
+### Wiki Sync Action
+
+**File:** `.github/workflows/wiki-sync.yml`
+
+Triggers on push to `main` when files in `docs/wiki/` change. Clones the wiki repo,
+copies all markdown files, commits, and pushes.
+
+**Prerequisite:** The wiki must be initialized manually via the GitHub UI (Settings →
+enable Wiki → create Home page). Actions cannot create the wiki repo.
+
+### `/document` Skill
+
+**File:** `.claude/skills/document/SKILL.md`
+
+Creates or updates wiki pages:
+
+```
+/document <feature or process name>
+```
+
+The skill:
+1. Explores the codebase to find relevant services, types, handlers, and tests
+2. Checks existing `docs/wiki/` pages for duplicates
+3. Generates a markdown page with frontmatter, overview, Mermaid diagrams, and source links
+4. Writes to `docs/wiki/<page-slug>.md`
+5. Updates `docs/wiki/_Sidebar.md` with the new page
+
+The skill does NOT commit or push — that follows the normal git workflow.
+
+### Doc Page Format
+
+Every wiki page uses YAML frontmatter:
+
+```markdown
+---
+title: Feature Name
+description: One-line description
+sources:
+  - packages/server/src/services/feature/service.ts
+  - packages/server/src/handlers/feature-handler.ts
+---
+```
+
+The `sources` list is the staleness detection mechanism — it lists every source file
+the page documents.
+
+### Staleness Detection in PR Review
+
+The Claude PR review workflow (`.github/workflows/claude-review.yml`) includes a
+documentation check:
+
+- If any file in the PR diff appears in a doc page's `sources:`, the review flags
+  that the documentation may need updating
+- If new service or handler files are added without being listed in any doc page's
+  `sources`, the review suggests creating documentation
+
+This piggybacks on the existing review — no extra workflow or CI minutes.
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,20 @@
+# Pensieve Documentation
+
+Pensieve is a personal memory assistant with a Telegram bot interface, PostgreSQL + pgvector storage, Ollama embeddings, and Claude API for reasoning.
+
+## Architecture
+
+- **Monorepo:** `packages/server` (runtime) + `packages/types` (shared types)
+- **Runtime:** Single TypeScript process running Express health endpoint + Telegram bot + cron scheduler
+- **Storage:** PostgreSQL with pgvector for semantic search
+- **Embeddings:** Ollama for local embedding generation
+- **Reasoning:** Claude API for intelligent responses
+
+## Pages
+
+- [Home](Home) — This page
+
+## Development
+
+- See [CLAUDE.md](https://github.com/ilarinie/pensieve/blob/main/CLAUDE.md) for development rules
+- See [GitHub Automation](https://github.com/ilarinie/pensieve/blob/main/docs/github-automation.md) for CI/CD and workflow docs

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -13,6 +13,7 @@ Pensieve is a personal memory assistant with a Telegram bot interface, PostgreSQ
 ## Pages
 
 - [Home](Home) — This page
+- [Health Check Endpoint](health-check-endpoint) — HTTP liveness endpoint
 
 ## Development
 

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,1 @@
+[Pensieve Repository](https://github.com/ilarinie/pensieve) | Auto-synced from `docs/wiki/` on merge to main

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,3 @@
+**Pensieve Wiki**
+
+- [Home](Home)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,3 +1,4 @@
 **Pensieve Wiki**
 
 - [Home](Home)
+- [Health Check Endpoint](health-check-endpoint)

--- a/docs/wiki/health-check-endpoint.md
+++ b/docs/wiki/health-check-endpoint.md
@@ -1,0 +1,51 @@
+---
+title: Health Check Endpoint
+description: Simple HTTP endpoint for monitoring server liveness
+sources:
+  - packages/server/src/app.ts
+  - packages/server/src/index.ts
+---
+
+# Health Check Endpoint
+
+## Overview
+
+Pensieve exposes a lightweight HTTP health check endpoint at `GET /health-check`. It returns a JSON response with `{ status: 'ok' }` and a `200` status code, confirming the Express server is running and accepting connections.
+
+The endpoint is registered as part of the Express app created by `createApp` in `app.ts`. The server is started in `index.ts`, which listens on the port defined by the `PORT` environment variable.
+
+This endpoint can be used by container orchestrators, load balancers, or uptime monitors to verify that the Pensieve process is alive.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as Monitoring Client
+    participant Express as Express Server
+    Client->>Express: GET /health-check
+    Express-->>Client: 200 { status: "ok" }
+```
+
+## Components
+
+### createApp
+
+[`createApp`](https://github.com/ilarinie/pensieve/blob/main/packages/server/src/app.ts)
+
+Factory function that creates and configures the Express application. Registers the `/health-check` route, which responds with `{ status: 'ok' }`. Returns the configured Express app instance without starting the server, keeping app creation separate from listening for testability.
+
+### Server entry point
+
+[`index.ts`](https://github.com/ilarinie/pensieve/blob/main/packages/server/src/index.ts)
+
+The process entry point. Calls `createApp()` to get the configured Express app, then starts listening on the port specified by the `PORT` environment variable.
+
+## API Reference
+
+| Method | Path            | Response Code | Response Body        |
+|--------|-----------------|---------------|----------------------|
+| GET    | `/health-check` | 200           | `{ "status": "ok" }` |
+
+## Related Pages
+
+- [Home](Home) — Project overview and architecture


### PR DESCRIPTION
## Summary
- Add wiki documentation page for the `GET /health-check` endpoint
- Update sidebar and Home page with link to new page

## Test plan
- [ ] Verify the wiki page renders correctly on GitHub
- [ ] Verify sidebar and Home page links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)