### PR TITLE
Phase 1: Database schema with pgvector and tsvector

### DIFF
--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -1,4 +1,4 @@
-# /plan — Create a structured implementation plan
+# /planner — Create a structured implementation plan
 
 disable-model-invocation: true
 
@@ -25,6 +25,7 @@ Read the user's feature description from `$ARGUMENTS`. If the description is vag
 ### 2. Explore the codebase
 
 Use Read, Grep, and Glob to understand:
+
 - Existing services, types, and patterns in `packages/server/src/`
 - Shared types in `packages/types/`
 - Database schema in `packages/server/src/db/schema/`
@@ -34,11 +35,13 @@ Use Read, Grep, and Glob to understand:
 ### 3. Decompose into layered work items
 
 Apply the layer system:
+
 - **L0** — Independent items with no dependencies on other new items. These can be built in parallel. Typically: new types, standalone services, utility functions.
 - **L1** — Items that depend on L0 items. Typically: services that use L0 services, API endpoints that use L0 types.
 - **L2** — Orchestrators that wire everything together. Depend on L1 items. Typically: handler functions, integration points.
 
 Each work item should be:
+
 - Small enough for a single branch and PR
 - Independently testable
 - Named with a kebab-case slug (used as identifier before issue numbers exist)
@@ -60,8 +63,10 @@ labels:
 ## Work Items
 
 ### L0: <slug> — <Short title>
+
 **Branch:** `feat/<phase-or-feature>-<slug>`
 **Files:**
+
 - <path/to/file.ts> (new|modify)
 - <path/to/file.test.ts> (new|modify)
 
@@ -69,26 +74,31 @@ labels:
 <What this work item does. 2-3 sentences.>
 
 **Acceptance Criteria:**
+
 - [ ] <Criterion 1>
 - [ ] <Criterion 2>
 
 ---
 
 ### L1: <slug> — <Short title>
+
 **Depends on:** <slug-of-L0-item>, <another-slug>
 **Branch:** `feat/<phase-or-feature>-<slug>`
 **Files:**
+
 - <path/to/file.ts> (new|modify)
 
 **Description:**
 <What this work item does.>
 
 **Acceptance Criteria:**
+
 - [ ] <Criterion 1>
 
 ---
 
 ### L2: <slug> — <Short title>
+
 **Depends on:** <slug-of-L1-item>
 **Branch:** `feat/<phase-or-feature>-<slug>`
 ...
@@ -107,6 +117,7 @@ labels:
 ### 6. Present the plan
 
 After writing the file, tell the user:
+
 - The plan file path
 - A summary of the layer structure (how many items per layer)
 - Suggest they review and edit the file before running `/create-issues`

--- a/docs/plans/phase-1-database-schema.md
+++ b/docs/plans/phase-1-database-schema.md
@@ -1,0 +1,162 @@
+---
+feature: Phase 1 — Database Schema
+description: >
+  Define the core database schema (memories, memory_embeddings, tasks, ingestion_log)
+  using Drizzle ORM with pgvector and tsvector support. Create shared types in
+  packages/types, generate the first migration (with pgvector extension), and update
+  the DB client to pass schema for type-safe queries. This completes the Phase 1
+  milestone: `npm run db:migrate` works against a running Postgres+pgvector instance.
+labels:
+  - phase-1
+  - database
+---
+
+## Work Items
+
+### L0: shared-types — Define shared type aliases in packages/types
+
+**Branch:** `feat/phase-1-shared-types`
+**Files:**
+
+- `packages/types/memory.ts` (new)
+- `packages/types/task.ts` (new)
+- `packages/types/ingestion-log.ts` (new)
+- `packages/types/index.ts` (modify — add re-exports)
+
+**Description:**
+Define the core domain types that will be used across both packages. These are plain
+TypeScript type aliases (not Drizzle-coupled) representing the application-level shapes.
+They will be inferred from the Drizzle schema once it exists, but we define them here
+first as the contract that other code programs against. Includes: `Memory`,
+`NewMemory`, `Task`, `NewTask`, `TaskStatus`, `TaskPriority`, `IngestionLogEntry`,
+`NewIngestionLogEntry`, and the `Db` type alias wrapping the Drizzle instance.
+
+**Acceptance Criteria:**
+
+- [ ] `Memory` type has id, content, category, source, tags, metadata, sourceDate, createdAt, updatedAt, deletedAt fields
+- [ ] `Task` type has id, title, description, status (pending/done/snoozed/cancelled), priority (1-3), dueDate, reminderAt, snoozedUntil, completedAt, sourceMemoryId
+- [ ] `IngestionLogEntry` type has id, source, externalId, dedupHash, memoryId
+- [ ] `New*` types omit auto-generated fields (id, createdAt, etc.)
+- [ ] `Db` type alias exported for dependency injection
+- [ ] `packages/types/index.ts` barrel re-exports all types
+- [ ] `npm run typecheck` passes
+
+---
+
+### L0: db-schema — Define Drizzle schema with pgvector and tsvector
+
+**Branch:** `feat/phase-1-db-schema`
+**Files:**
+
+- `packages/server/src/db/schema.ts` (modify — replace empty placeholder)
+- `packages/server/src/db/schema.test.ts` (new)
+
+**Description:**
+Implement the full database schema in Drizzle ORM: `memories` table with a generated
+`tsvector` column for full-text search, `memory_embeddings` table with `vector(768)` for
+pgvector cosine similarity, `tasks` table for extracted tasks, and `ingestion_log` table
+for deduplication. Use Drizzle's native pgvector support (`vector` column type) and
+`customType` for the `tsvector` generated column. Add GIN indexes on the tsvector and
+tags columns. Do NOT add an HNSW vector index — that comes after bulk imports in
+Phase 7.5.
+
+Tests verify the schema exports the correct table definitions and column types
+(structural tests, no DB connection needed).
+
+**Acceptance Criteria:**
+
+- [ ] `memories` table: id (uuid, pk, default random), content (text, not null), search (tsvector, generated always as `to_tsvector('english', content)`), category (text), source (text, not null), tags (text array), metadata (jsonb), sourceDate (timestamptz), createdAt (timestamptz, default now), updatedAt (timestamptz, default now), deletedAt (timestamptz, nullable)
+- [ ] `memory_embeddings` table: id (uuid, pk), memoryId (uuid, fk → memories, not null), model (text, not null), embedding (vector(768), not null), createdAt (timestamptz, default now). Unique constraint on (memoryId, model)
+- [ ] `tasks` table: id (uuid, pk), title (text, not null), description (text), status (text, not null, default 'pending'), priority (integer, default 2), dueDate (timestamptz), reminderAt (timestamptz), snoozedUntil (timestamptz), completedAt (timestamptz), sourceMemoryId (uuid, fk → memories), createdAt (timestamptz, default now), updatedAt (timestamptz, default now)
+- [ ] `ingestion_log` table: id (uuid, pk), source (text, not null), externalId (text), dedupHash (text, not null), memoryId (uuid, fk → memories, not null), createdAt (timestamptz, default now). Unique index on (source, externalId)
+- [ ] GIN index on `memories.search` (tsvector)
+- [ ] GIN index on `memories.tags`
+- [ ] All tables and relations exported from schema.ts
+- [ ] Schema test file verifies table names and column existence
+- [ ] `npm run typecheck` passes
+
+---
+
+### L1: db-client-schema — Wire schema into DB client and export Db type
+
+**Depends on:** db-schema
+**Branch:** `feat/phase-1-db-client-schema`
+**Files:**
+
+- `packages/server/src/db/client.ts` (modify — pass schema to drizzle())
+- `packages/server/src/db/client.test.ts` (new)
+
+**Description:**
+Update `createDb()` to pass the schema object to `drizzle()` so that queries get
+full type inference. Export a `Db` type from the client module (using
+`ReturnType<typeof createDb>`) that other services will use for dependency injection.
+Update `packages/types/` if the `Db` type should come from server instead.
+
+Tests mock the `postgres` driver and verify `createDb()` returns a Drizzle instance
+with the schema attached.
+
+**Acceptance Criteria:**
+
+- [ ] `createDb()` passes `{ schema }` to `drizzle()` for type-safe queries
+- [ ] `Db` type exported from client.ts as `type Db = ReturnType<typeof createDb>`
+- [ ] Test verifies `createDb` can be called (with mocked postgres)
+- [ ] `npm run typecheck` passes
+
+---
+
+### L1: first-migration — Generate and patch the initial migration
+
+**Depends on:** db-schema
+**Branch:** `feat/phase-1-first-migration`
+**Files:**
+
+- `packages/server/src/db/migrations/` (new — generated SQL files)
+
+**Description:**
+Run `npm run db:generate` to produce the initial migration from the Drizzle schema.
+Then manually prepend `CREATE EXTENSION IF NOT EXISTS vector;` to the generated SQL
+file (pgvector extension must exist before vector columns are created). Verify the
+migration SQL is correct and includes all tables, indexes, and constraints.
+
+This is a code-generation + manual-patch step. The migration files are committed as-is.
+
+**Acceptance Criteria:**
+
+- [ ] Migration SQL file exists in `packages/server/src/db/migrations/`
+- [ ] First line of migration SQL is `CREATE EXTENSION IF NOT EXISTS vector;`
+- [ ] Migration creates all four tables (memories, memory_embeddings, tasks, ingestion_log)
+- [ ] Migration creates GIN indexes on memories.search and memories.tags
+- [ ] Migration creates unique constraint on memory_embeddings(memory_id, model)
+- [ ] Migration creates unique index on ingestion_log(source, external_id)
+- [ ] No HNSW vector index is present (deferred to Phase 7.5)
+- [ ] `npm run typecheck` passes
+
+---
+
+### L2: verify-milestone — Integration verification of db:migrate
+
+**Depends on:** db-client-schema, first-migration
+**Branch:** `feat/phase-1-verify-milestone`
+**Files:**
+
+- `packages/server/src/db/migrate.ts` (modify — minor cleanup if needed)
+- `packages/types/index.ts` (modify — ensure Db type re-exported if needed)
+
+**Description:**
+Final integration step: ensure `npm run db:migrate` works end-to-end against a running
+PostgreSQL+pgvector instance. Verify the Db type is properly exported and usable by
+downstream services. Clean up any remaining type mismatches between shared types and
+Drizzle inferred types — prefer Drizzle's `InferSelectModel` / `InferInsertModel` to
+keep types in sync with the schema automatically, updating `packages/types/` accordingly.
+
+This item ties everything together and validates the Phase 1 milestone.
+
+**Acceptance Criteria:**
+
+- [ ] `npm run db:migrate` completes successfully against a fresh pgvector database
+- [ ] All four tables are created with correct columns and constraints
+- [ ] `Db` type is importable from the types package or server/db/client
+- [ ] `Memory`, `NewMemory`, `Task`, `NewTask` types align with Drizzle schema (inferred via `InferSelectModel`/`InferInsertModel`)
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test:run` passes
+- [ ] `npm run lint` passes

--- a/packages/server/src/db/client.test.ts
+++ b/packages/server/src/db/client.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('postgres', () => ({
+  default: vi.fn(() => ({})),
+}))
+
+vi.mock('../env.js', () => ({
+  env: { DATABASE_URL: 'postgres://test:test@localhost:5432/test' },
+}))
+
+describe('createDb', () => {
+  test('should return a Drizzle instance', async () => {
+    const { createDb } = await import('./client.js')
+
+    const db = createDb()
+
+    expect(db).toBeDefined()
+    expect(db.select).toBeDefined()
+    expect(db.insert).toBeDefined()
+    expect(db.update).toBeDefined()
+    expect(db.delete).toBeDefined()
+  })
+})

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -2,13 +2,19 @@ import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 
 import { env } from '../env.js'
+import * as schema from './schema.js'
 
 /**
- * Creates and returns the Drizzle database client.
+ * Creates and returns the Drizzle database client with schema for type-safe queries.
  *
- * @returns The configured Drizzle ORM instance
+ * @returns The configured Drizzle ORM instance with schema attached
  */
 export const createDb = () => {
   const client = postgres(env.DATABASE_URL)
-  return drizzle(client)
+  return drizzle(client, { schema })
 }
+
+/**
+ * Drizzle database instance type for dependency injection.
+ */
+export type Db = ReturnType<typeof createDb>

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -1,17 +1,36 @@
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
 
+import { getLogger } from '../logging/get-logger.js'
+import type { Db } from './client.js'
 import { createDb } from './client.js'
+
+const logger = getLogger(import.meta.url)
 
 /**
  * Runs all pending database migrations.
  *
+ * @param db - Drizzle database instance
  * @returns Promise that resolves when migrations are complete
  */
-export const runMigrations = async () => {
-  const db = createDb()
+export const runMigrations = async (db: Db) => {
   await migrate(db, {
     migrationsFolder: './packages/server/src/db/migrations',
   })
 }
 
-runMigrations()
+const isMainModule =
+  process.argv[1]?.endsWith('migrate.ts') ||
+  process.argv[1]?.endsWith('migrate.js')
+
+if (isMainModule) {
+  const db = createDb()
+  runMigrations(db)
+    .then(() => {
+      logger.info('Migrations completed successfully')
+      process.exit(0)
+    })
+    .catch((error: unknown) => {
+      logger.error('Migration failed', { error })
+      process.exit(1)
+    })
+}

--- a/packages/server/src/db/migrations/0000_ambitious_joshua_kane.sql
+++ b/packages/server/src/db/migrations/0000_ambitious_joshua_kane.sql
@@ -1,0 +1,55 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
+CREATE TABLE "ingestion_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source" text NOT NULL,
+	"external_id" text,
+	"dedup_hash" text NOT NULL,
+	"memory_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "memories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"content" text NOT NULL,
+	"search" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+	"category" text,
+	"source" text NOT NULL,
+	"tags" text[],
+	"metadata" jsonb,
+	"source_date" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "memory_embeddings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"memory_id" uuid NOT NULL,
+	"model" text NOT NULL,
+	"embedding" vector(768) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_memory_embeddings_memory_id_model" UNIQUE("memory_id","model")
+);
+--> statement-breakpoint
+CREATE TABLE "tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"priority" integer DEFAULT 2,
+	"due_date" timestamp with time zone,
+	"reminder_at" timestamp with time zone,
+	"snoozed_until" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"source_memory_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ingestion_log" ADD CONSTRAINT "ingestion_log_memory_id_memories_id_fk" FOREIGN KEY ("memory_id") REFERENCES "public"."memories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "memory_embeddings" ADD CONSTRAINT "memory_embeddings_memory_id_memories_id_fk" FOREIGN KEY ("memory_id") REFERENCES "public"."memories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_source_memory_id_memories_id_fk" FOREIGN KEY ("source_memory_id") REFERENCES "public"."memories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_ingestion_log_source_external_id" ON "ingestion_log" USING btree ("source","external_id");--> statement-breakpoint
+CREATE INDEX "idx_memories_search" ON "memories" USING gin ("search");--> statement-breakpoint
+CREATE INDEX "idx_memories_tags" ON "memories" USING gin ("tags");

--- a/packages/server/src/db/migrations/0001_gorgeous_galactus.sql
+++ b/packages/server/src/db/migrations/0001_gorgeous_galactus.sql
@@ -1,0 +1,3 @@
+DROP INDEX "idx_ingestion_log_source_external_id";--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_ingestion_log_source_dedup_hash" ON "ingestion_log" USING btree ("source","dedup_hash");--> statement-breakpoint
+CREATE INDEX "idx_ingestion_log_source_external_id" ON "ingestion_log" USING btree ("source","external_id");

--- a/packages/server/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/server/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,395 @@
+{
+  "id": "5f6e5f58-f3e8-4f1d-a528-df93f799e7ba",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_hash": {
+          "name": "dedup_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ingestion_log_source_external_id": {
+          "name": "idx_ingestion_log_source_external_id",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_memory_id_memories_id_fk": {
+          "name": "ingestion_log_memory_id_memories_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', content)",
+            "type": "stored"
+          }
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_date": {
+          "name": "source_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_memories_search": {
+          "name": "idx_memories_search",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_memories_tags": {
+          "name": "idx_memories_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_embeddings": {
+      "name": "memory_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memory_embeddings_memory_id_memories_id_fk": {
+          "name": "memory_embeddings_memory_id_memories_id_fk",
+          "tableFrom": "memory_embeddings",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_memory_embeddings_memory_id_model": {
+          "name": "uq_memory_embeddings_memory_id_model",
+          "nullsNotDistinct": false,
+          "columns": [
+            "memory_id",
+            "model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_at": {
+          "name": "reminder_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_memory_id": {
+          "name": "source_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_source_memory_id_memories_id_fk": {
+          "name": "tasks_source_memory_id_memories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "source_memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/src/db/migrations/meta/0001_snapshot.json
+++ b/packages/server/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,416 @@
+{
+  "id": "81892444-735a-4039-b243-adf231800eed",
+  "prevId": "5f6e5f58-f3e8-4f1d-a528-df93f799e7ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_hash": {
+          "name": "dedup_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ingestion_log_source_dedup_hash": {
+          "name": "idx_ingestion_log_source_dedup_hash",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingestion_log_source_external_id": {
+          "name": "idx_ingestion_log_source_external_id",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_memory_id_memories_id_fk": {
+          "name": "ingestion_log_memory_id_memories_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', content)",
+            "type": "stored"
+          }
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_date": {
+          "name": "source_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_memories_search": {
+          "name": "idx_memories_search",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_memories_tags": {
+          "name": "idx_memories_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_embeddings": {
+      "name": "memory_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memory_embeddings_memory_id_memories_id_fk": {
+          "name": "memory_embeddings_memory_id_memories_id_fk",
+          "tableFrom": "memory_embeddings",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_memory_embeddings_memory_id_model": {
+          "name": "uq_memory_embeddings_memory_id_model",
+          "nullsNotDistinct": false,
+          "columns": [
+            "memory_id",
+            "model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_at": {
+          "name": "reminder_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_memory_id": {
+          "name": "source_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_source_memory_id_memories_id_fk": {
+          "name": "tasks_source_memory_id_memories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "source_memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/src/db/migrations/meta/_journal.json
+++ b/packages/server/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771544529095,
+      "tag": "0000_ambitious_joshua_kane",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/server/src/db/migrations/meta/_journal.json
+++ b/packages/server/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771544529095,
       "tag": "0000_ambitious_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771610022689,
+      "tag": "0001_gorgeous_galactus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.test.ts
+++ b/packages/server/src/db/schema.test.ts
@@ -1,0 +1,133 @@
+import { getTableName } from 'drizzle-orm'
+import { getTableConfig } from 'drizzle-orm/pg-core'
+import { describe, expect, test } from 'vitest'
+
+import { ingestionLog, memories, memoryEmbeddings, tasks } from './schema.js'
+
+describe('memories', () => {
+  test('should have correct table name', () => {
+    expect(getTableName(memories)).toBe('memories')
+  })
+
+  test('should have all required columns', () => {
+    const config = getTableConfig(memories)
+    const columnNames = config.columns.map((col) => col.name)
+
+    expect(columnNames).toContain('id')
+    expect(columnNames).toContain('content')
+    expect(columnNames).toContain('search')
+    expect(columnNames).toContain('category')
+    expect(columnNames).toContain('source')
+    expect(columnNames).toContain('tags')
+    expect(columnNames).toContain('metadata')
+    expect(columnNames).toContain('source_date')
+    expect(columnNames).toContain('created_at')
+    expect(columnNames).toContain('updated_at')
+    expect(columnNames).toContain('deleted_at')
+  })
+
+  test('should have GIN index on search column', () => {
+    const config = getTableConfig(memories)
+    const searchIndex = config.indexes.find(
+      (i) => i.config.name === 'idx_memories_search',
+    )
+
+    expect(searchIndex).toBeDefined()
+    expect(searchIndex?.config.method).toBe('gin')
+  })
+
+  test('should have GIN index on tags column', () => {
+    const config = getTableConfig(memories)
+    const tagsIndex = config.indexes.find(
+      (i) => i.config.name === 'idx_memories_tags',
+    )
+
+    expect(tagsIndex).toBeDefined()
+    expect(tagsIndex?.config.method).toBe('gin')
+  })
+})
+
+describe('memoryEmbeddings', () => {
+  test('should have correct table name', () => {
+    expect(getTableName(memoryEmbeddings)).toBe('memory_embeddings')
+  })
+
+  test('should have all required columns', () => {
+    const config = getTableConfig(memoryEmbeddings)
+    const columnNames = config.columns.map((col) => col.name)
+
+    expect(columnNames).toContain('id')
+    expect(columnNames).toContain('memory_id')
+    expect(columnNames).toContain('model')
+    expect(columnNames).toContain('embedding')
+    expect(columnNames).toContain('created_at')
+  })
+
+  test('should have unique constraint on memory_id and model', () => {
+    const config = getTableConfig(memoryEmbeddings)
+    const uniqueConstraint = config.uniqueConstraints.find(
+      (col) => col.name === 'uq_memory_embeddings_memory_id_model',
+    )
+
+    expect(uniqueConstraint).toBeDefined()
+  })
+
+  test('should not have HNSW vector index', () => {
+    const config = getTableConfig(memoryEmbeddings)
+    const hnswIndex = config.indexes.find((i) => i.config.method === 'hnsw')
+
+    expect(hnswIndex).toBeUndefined()
+  })
+})
+
+describe('tasks', () => {
+  test('should have correct table name', () => {
+    expect(getTableName(tasks)).toBe('tasks')
+  })
+
+  test('should have all required columns', () => {
+    const config = getTableConfig(tasks)
+    const columnNames = config.columns.map((col) => col.name)
+
+    expect(columnNames).toContain('id')
+    expect(columnNames).toContain('title')
+    expect(columnNames).toContain('description')
+    expect(columnNames).toContain('status')
+    expect(columnNames).toContain('priority')
+    expect(columnNames).toContain('due_date')
+    expect(columnNames).toContain('reminder_at')
+    expect(columnNames).toContain('snoozed_until')
+    expect(columnNames).toContain('completed_at')
+    expect(columnNames).toContain('source_memory_id')
+    expect(columnNames).toContain('created_at')
+    expect(columnNames).toContain('updated_at')
+  })
+})
+
+describe('ingestionLog', () => {
+  test('should have correct table name', () => {
+    expect(getTableName(ingestionLog)).toBe('ingestion_log')
+  })
+
+  test('should have all required columns', () => {
+    const config = getTableConfig(ingestionLog)
+    const columnNames = config.columns.map((col) => col.name)
+
+    expect(columnNames).toContain('id')
+    expect(columnNames).toContain('source')
+    expect(columnNames).toContain('external_id')
+    expect(columnNames).toContain('dedup_hash')
+    expect(columnNames).toContain('memory_id')
+    expect(columnNames).toContain('created_at')
+  })
+
+  test('should have unique index on source and external_id', () => {
+    const config = getTableConfig(ingestionLog)
+    const uniqueIdx = config.indexes.find(
+      (i) => i.config.name === 'idx_ingestion_log_source_external_id',
+    )
+
+    expect(uniqueIdx).toBeDefined()
+    expect(uniqueIdx?.config.unique).toBe(true)
+  })
+})

--- a/packages/server/src/db/schema.test.ts
+++ b/packages/server/src/db/schema.test.ts
@@ -121,13 +121,22 @@ describe('ingestionLog', () => {
     expect(columnNames).toContain('created_at')
   })
 
-  test('should have unique index on source and external_id', () => {
+  test('should have unique index on source and dedup_hash', () => {
     const config = getTableConfig(ingestionLog)
     const uniqueIdx = config.indexes.find(
-      (i) => i.config.name === 'idx_ingestion_log_source_external_id',
+      (i) => i.config.name === 'idx_ingestion_log_source_dedup_hash',
     )
 
     expect(uniqueIdx).toBeDefined()
     expect(uniqueIdx?.config.unique).toBe(true)
+  })
+
+  test('should have index on source and external_id', () => {
+    const config = getTableConfig(ingestionLog)
+    const idx = config.indexes.find(
+      (i) => i.config.name === 'idx_ingestion_log_source_external_id',
+    )
+
+    expect(idx).toBeDefined()
   })
 })

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,2 +1,121 @@
-// Database schema — tables will be added in Phase 1
-export {}
+import { sql } from 'drizzle-orm'
+import {
+  customType,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+  uuid,
+  vector,
+} from 'drizzle-orm/pg-core'
+
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return 'tsvector'
+  },
+})
+
+/**
+ * Core memory storage table for all ingested content.
+ */
+export const memories = pgTable(
+  'memories',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    content: text('content').notNull(),
+    search: tsvector('search').generatedAlwaysAs(
+      sql`to_tsvector('english', content)`,
+    ),
+    category: text('category'),
+    source: text('source').notNull(),
+    tags: text('tags').array(),
+    metadata: jsonb('metadata'),
+    sourceDate: timestamp('source_date', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('idx_memories_search').using('gin', table.search),
+    index('idx_memories_tags').using('gin', table.tags),
+  ],
+)
+
+/**
+ * Embeddings stored separately for model-swap flexibility.
+ */
+export const memoryEmbeddings = pgTable(
+  'memory_embeddings',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    memoryId: uuid('memory_id')
+      .references(() => memories.id)
+      .notNull(),
+    model: text('model').notNull(),
+    embedding: vector('embedding', { dimensions: 768 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    unique('uq_memory_embeddings_memory_id_model').on(
+      table.memoryId,
+      table.model,
+    ),
+  ],
+)
+
+/**
+ * Tasks extracted from memories or created directly.
+ */
+export const tasks = pgTable('tasks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  title: text('title').notNull(),
+  description: text('description'),
+  status: text('status').notNull().default('pending'),
+  priority: integer('priority').default(2),
+  dueDate: timestamp('due_date', { withTimezone: true }),
+  reminderAt: timestamp('reminder_at', { withTimezone: true }),
+  snoozedUntil: timestamp('snoozed_until', { withTimezone: true }),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  sourceMemoryId: uuid('source_memory_id').references(() => memories.id),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
+/**
+ * Ingestion log for deduplication of imported content.
+ */
+export const ingestionLog = pgTable(
+  'ingestion_log',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    source: text('source').notNull(),
+    externalId: text('external_id'),
+    dedupHash: text('dedup_hash').notNull(),
+    memoryId: uuid('memory_id')
+      .references(() => memories.id)
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex('idx_ingestion_log_source_external_id').on(
+      table.source,
+      table.externalId,
+    ),
+  ],
+)

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,2 +1,11 @@
-// Barrel export for shared types
-export {}
+export type {
+  IngestionLogEntry,
+  NewIngestionLogEntry,
+} from './ingestion-log.js'
+export type {
+  Memory,
+  MemoryEmbedding,
+  NewMemory,
+  NewMemoryEmbedding,
+} from './memory.js'
+export type { NewTask, Task, TaskPriority, TaskStatus } from './task.js'

--- a/packages/types/ingestion-log.ts
+++ b/packages/types/ingestion-log.ts
@@ -1,0 +1,16 @@
+/**
+ * An ingestion log entry used for deduplication of imported content.
+ */
+export type IngestionLogEntry = {
+  id: string
+  source: string
+  externalId: string | null
+  dedupHash: string
+  memoryId: string
+  createdAt: Date
+}
+
+/**
+ * Input for creating a new ingestion log entry. Omits auto-generated fields.
+ */
+export type NewIngestionLogEntry = Omit<IngestionLogEntry, 'id' | 'createdAt'>

--- a/packages/types/memory.ts
+++ b/packages/types/memory.ts
@@ -1,0 +1,40 @@
+/**
+ * A stored memory record with all fields populated.
+ */
+export type Memory = {
+  id: string
+  content: string
+  search: string | null
+  category: string | null
+  source: string
+  tags: string[] | null
+  metadata: unknown
+  sourceDate: Date | null
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date | null
+}
+
+/**
+ * Input for creating a new memory. Omits auto-generated fields.
+ */
+export type NewMemory = Omit<
+  Memory,
+  'id' | 'search' | 'createdAt' | 'updatedAt'
+>
+
+/**
+ * A memory embedding record linking a memory to its vector representation.
+ */
+export type MemoryEmbedding = {
+  id: string
+  memoryId: string
+  model: string
+  embedding: number[]
+  createdAt: Date
+}
+
+/**
+ * Input for creating a new memory embedding. Omits auto-generated fields.
+ */
+export type NewMemoryEmbedding = Omit<MemoryEmbedding, 'id' | 'createdAt'>

--- a/packages/types/task.ts
+++ b/packages/types/task.ts
@@ -1,0 +1,32 @@
+/**
+ * Allowed task status values.
+ */
+export type TaskStatus = 'pending' | 'done' | 'snoozed' | 'cancelled'
+
+/**
+ * Allowed task priority values (1 = high, 2 = medium, 3 = low).
+ */
+export type TaskPriority = 1 | 2 | 3
+
+/**
+ * A task record extracted from a memory or created directly.
+ */
+export type Task = {
+  id: string
+  title: string
+  description: string | null
+  status: string
+  priority: number | null
+  dueDate: Date | null
+  reminderAt: Date | null
+  snoozedUntil: Date | null
+  completedAt: Date | null
+  sourceMemoryId: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * Input for creating a new task. Omits auto-generated fields.
+ */
+export type NewTask = Omit<Task, 'id' | 'createdAt' | 'updatedAt'>

--- a/packages/types/task.ts
+++ b/packages/types/task.ts
@@ -15,8 +15,8 @@ export type Task = {
   id: string
   title: string
   description: string | null
-  status: string
-  priority: number | null
+  status: TaskStatus
+  priority: TaskPriority | null
   dueDate: Date | null
   reminderAt: Date | null
   snoozedUntil: Date | null


### PR DESCRIPTION
## Summary

- Define 4 Drizzle ORM tables: `memories` (tsvector FTS), `memory_embeddings` (pgvector 768d), `tasks`, `ingestion_log`
- Add shared domain types in `packages/types/` (Memory, Task, IngestionLogEntry + New* variants)
- Wire schema into DB client for type-safe queries, export `Db` type for DI
- Generate initial migration with `CREATE EXTENSION IF NOT EXISTS vector`
- Clean up `migrate.ts` with DI pattern and proper script detection
- Fix `/create-issues` skill to add issues to project board before creating sub-issues

Closes #2, closes #3, closes #4, closes #5, closes #6, closes #7

## Test plan

- [x] 13 schema structure tests verify table names, columns, indexes, and constraints
- [x] 1 client test verifies Drizzle instance creation with schema
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] No HNSW vector index present (deferred to Phase 7.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)