### PR TITLE
feat: add store-memory service with dedup

### DIFF
--- a/packages/server/src/services/memory/index.ts
+++ b/packages/server/src/services/memory/index.ts
@@ -1,0 +1,2 @@
+export { storeMemory } from './store-memory.js'
+export type { StoreMemoryInput, StoreMemoryResult } from './store-memory.js'

--- a/packages/server/src/services/memory/store-memory.test.ts
+++ b/packages/server/src/services/memory/store-memory.test.ts
@@ -1,0 +1,226 @@
+import { createHash } from 'node:crypto'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { storeMemory } from './store-memory.js'
+
+vi.mock('../../logging/get-logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+const computeExpectedHash = (
+  source: string,
+  sourceDate: Date | null | undefined,
+  content: string,
+) => {
+  const dateStr = sourceDate?.toISOString() ?? ''
+  return createHash('sha256')
+    .update(`${source}:${dateStr}:${content}`)
+    .digest('hex')
+}
+
+const mockMemory = {
+  id: 'mem-123',
+  content: 'test content',
+  search: null,
+  category: null,
+  source: 'telegram',
+  tags: null,
+  metadata: null,
+  sourceDate: null,
+  createdAt: new Date('2026-02-20T10:00:00Z'),
+  updatedAt: new Date('2026-02-20T10:00:00Z'),
+  deletedAt: null,
+}
+
+const createMockTx = (opts: { hasDuplicate?: boolean } = {}) => {
+  const mockLimit = vi
+    .fn()
+    .mockResolvedValue(opts.hasDuplicate ? [{ id: 'existing' }] : [])
+  const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit })
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere })
+  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom })
+
+  const mockInsert = vi.fn().mockImplementation(() => ({
+    values: vi.fn().mockImplementation(() => ({
+      returning: vi.fn().mockResolvedValue([mockMemory]),
+      then(
+        onFulfilled: (v: unknown) => unknown,
+        onRejected?: (e: unknown) => unknown,
+      ) {
+        return Promise.resolve(undefined).then(onFulfilled, onRejected)
+      },
+    })),
+  }))
+
+  return { select: mockSelect, insert: mockInsert }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockDb = (opts: { hasDuplicate?: boolean } = {}): any => {
+  const tx = createMockTx(opts)
+  return {
+    transaction: vi.fn(
+      async (fn: (tx: ReturnType<typeof createMockTx>) => Promise<unknown>) =>
+        fn(tx),
+    ),
+    mockTx: tx,
+  }
+}
+
+const getInsertValues = (
+  tx: ReturnType<typeof createMockTx>,
+  callIndex: number,
+) => {
+  const [valuesCall] = tx.insert.mock.results[callIndex].value.values.mock.calls
+  return valuesCall[0]
+}
+
+describe('storeMemory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('should insert memory and ingestion log in a transaction', async () => {
+    const db = createMockDb()
+    const input = {
+      content: 'Remember to buy milk',
+      source: 'telegram',
+    }
+
+    const result = await storeMemory(db, input)
+
+    expect(result.deduplicated).toBe(false)
+    expect(result.data).toEqual(mockMemory)
+    expect(db.transaction).toHaveBeenCalledOnce()
+  })
+
+  test('should call insert for memories table with correct values', async () => {
+    const db = createMockDb()
+    const sourceDate = new Date('2026-02-20T12:00:00Z')
+    const input = {
+      content: 'Remember to buy milk',
+      source: 'telegram',
+      category: 'task',
+      tags: ['shopping'],
+      metadata: { chatId: 123 },
+      sourceDate,
+    }
+
+    await storeMemory(db, input)
+
+    expect(getInsertValues(db.mockTx, 0)).toEqual({
+      content: 'Remember to buy milk',
+      source: 'telegram',
+      category: 'task',
+      tags: ['shopping'],
+      metadata: { chatId: 123 },
+      sourceDate,
+      deletedAt: null,
+    })
+  })
+
+  test('should call insert for ingestion log with dedup hash', async () => {
+    const db = createMockDb()
+    const input = {
+      content: 'Remember to buy milk',
+      source: 'telegram',
+      externalId: 'msg-456',
+    }
+
+    await storeMemory(db, input)
+
+    expect(db.mockTx.insert).toHaveBeenCalledTimes(2)
+
+    const expectedHash = computeExpectedHash(
+      'telegram',
+      null,
+      'Remember to buy milk',
+    )
+    expect(getInsertValues(db.mockTx, 1)).toEqual({
+      source: 'telegram',
+      externalId: 'msg-456',
+      dedupHash: expectedHash,
+      memoryId: 'mem-123',
+    })
+  })
+
+  test('should compute dedup hash from source + sourceDate + content', async () => {
+    const db = createMockDb()
+    const sourceDate = new Date('2026-02-20T12:00:00Z')
+    const input = {
+      content: 'test content',
+      source: 'whatsapp',
+      sourceDate,
+    }
+
+    await storeMemory(db, input)
+
+    const expectedHash = computeExpectedHash(
+      'whatsapp',
+      sourceDate,
+      'test content',
+    )
+    expect(getInsertValues(db.mockTx, 1).dedupHash).toBe(expectedHash)
+  })
+
+  test('should return deduplicated result when hash already exists', async () => {
+    const db = createMockDb({ hasDuplicate: true })
+    const input = {
+      content: 'duplicate content',
+      source: 'telegram',
+    }
+
+    const result = await storeMemory(db, input)
+
+    expect(result).toEqual({ data: null, deduplicated: true })
+  })
+
+  test('should not insert when duplicate is detected', async () => {
+    const db = createMockDb({ hasDuplicate: true })
+    const input = {
+      content: 'duplicate content',
+      source: 'telegram',
+    }
+
+    await storeMemory(db, input)
+
+    expect(db.mockTx.insert).not.toHaveBeenCalled()
+  })
+
+  test('should use null for optional fields when not provided', async () => {
+    const db = createMockDb()
+    const input = {
+      content: 'minimal input',
+      source: 'telegram',
+    }
+
+    await storeMemory(db, input)
+
+    expect(getInsertValues(db.mockTx, 0)).toEqual({
+      content: 'minimal input',
+      source: 'telegram',
+      category: null,
+      tags: null,
+      metadata: null,
+      sourceDate: null,
+      deletedAt: null,
+    })
+  })
+
+  test('should use null for externalId when not provided', async () => {
+    const db = createMockDb()
+    const input = {
+      content: 'test',
+      source: 'telegram',
+    }
+
+    await storeMemory(db, input)
+
+    expect(getInsertValues(db.mockTx, 1).externalId).toBeNull()
+  })
+})

--- a/packages/server/src/services/memory/store-memory.ts
+++ b/packages/server/src/services/memory/store-memory.ts
@@ -1,0 +1,113 @@
+import { and, eq } from 'drizzle-orm'
+import { createHash } from 'node:crypto'
+
+import type { Memory } from '../../../../types/index.js'
+import type { Db } from '../../db/client.js'
+import { ingestionLog, memories } from '../../db/schema.js'
+import { getLogger } from '../../logging/get-logger.js'
+
+const logger = getLogger(import.meta.url)
+
+/**
+ * Input for storing a new memory with optional dedup fields.
+ */
+export type StoreMemoryInput = {
+  content: string
+  source: string
+  category?: string | null
+  tags?: string[] | null
+  metadata?: unknown
+  sourceDate?: Date | null
+  externalId?: string | null
+}
+
+/**
+ * Result of a store memory operation.
+ * Either the created memory or a dedup-skip indicator.
+ */
+export type StoreMemoryResult =
+  | { data: Memory; deduplicated: false }
+  | { data: null; deduplicated: true }
+
+const computeDedupHash = (
+  source: string,
+  sourceDate: Date | null | undefined,
+  content: string,
+): string => {
+  const dateStr = sourceDate?.toISOString() ?? ''
+  return createHash('sha256')
+    .update(`${source}:${dateStr}:${content}`)
+    .digest('hex')
+}
+
+/**
+ * Stores a new memory in the database with deduplication.
+ *
+ * Inserts into the `memories` and `ingestion_log` tables atomically within a
+ * transaction. Computes a SHA-256 dedup hash from source + sourceDate + content.
+ * If a matching hash already exists for the same source, returns a dedup-skip
+ * result instead of inserting.
+ *
+ * @param db - Drizzle database instance
+ * @param input - Memory content, metadata, and optional dedup fields
+ * @returns The created memory or a dedup-skip indicator
+ */
+export const storeMemory = async (
+  db: Db,
+  input: StoreMemoryInput,
+): Promise<StoreMemoryResult> => {
+  const dedupHash = computeDedupHash(
+    input.source,
+    input.sourceDate,
+    input.content,
+  )
+
+  const result = await db.transaction(async (tx) => {
+    const existing = await tx
+      .select()
+      .from(ingestionLog)
+      .where(
+        and(
+          eq(ingestionLog.source, input.source),
+          eq(ingestionLog.dedupHash, dedupHash),
+        ),
+      )
+      .limit(1)
+
+    if (existing.length > 0) {
+      logger.debug('Duplicate memory detected, skipping', {
+        source: input.source,
+        dedupHash,
+      })
+      return null
+    }
+
+    const [memory] = await tx
+      .insert(memories)
+      .values({
+        content: input.content,
+        source: input.source,
+        category: input.category ?? null,
+        tags: input.tags ?? null,
+        metadata: input.metadata ?? null,
+        sourceDate: input.sourceDate ?? null,
+        deletedAt: null,
+      })
+      .returning()
+
+    await tx.insert(ingestionLog).values({
+      source: input.source,
+      externalId: input.externalId ?? null,
+      dedupHash,
+      memoryId: memory.id,
+    })
+
+    return memory
+  })
+
+  if (!result) {
+    return { data: null, deduplicated: true }
+  }
+
+  return { data: result as Memory, deduplicated: false }
+}


### PR DESCRIPTION
Closes #11

## Summary

Adds the `storeMemory` service function that inserts memories into the database with SHA-256 deduplication. The function atomically inserts into both `memories` and `ingestion_log` tables within a transaction, computing a dedup hash from `source + sourceDate + content`.

## Changes

- `packages/server/src/services/memory/store-memory.ts` (new) — `storeMemory(db, input)` function with SHA-256 dedup, transactional insert, and typed result (`StoreMemoryResult`)
- `packages/server/src/services/memory/store-memory.test.ts` (new) — 8 tests covering insert, dedup detection, hash computation, optional field defaults
- `packages/server/src/services/memory/index.ts` (new) — barrel re-exports

## Test Coverage

8 tests:
- Transactional insert of memory + ingestion log
- Correct values passed to memories insert (with all optional fields)
- Correct dedup hash and external ID in ingestion log insert
- SHA-256 hash computed from source + sourceDate + content
- Duplicate detection returns `{ data: null, deduplicated: true }`
- No insert when duplicate detected
- Null defaults for optional fields
- Null externalId when not provided

## Checklist

- [x] Tests pass (`npm run test:run`)
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports