### PR TITLE
feat: add Ollama embedding service

### DIFF
--- a/packages/server/src/services/embedding/generate-embedding.test.ts
+++ b/packages/server/src/services/embedding/generate-embedding.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { generateEmbedding } from './generate-embedding.js'
+
+const OLLAMA_URL = 'http://localhost:11434'
+const MODEL = 'nomic-embed-text'
+const MOCK_EMBEDDING = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+describe('generateEmbedding', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ embeddings: [MOCK_EMBEDDING] }),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('should call Ollama /api/embed with correct request', async () => {
+    await generateEmbedding(OLLAMA_URL, MODEL, 'hello world')
+
+    expect(fetch).toHaveBeenCalledWith(`${OLLAMA_URL}/api/embed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: MODEL, input: 'hello world' }),
+    })
+  })
+
+  test('should return the embedding vector', async () => {
+    const result = await generateEmbedding(OLLAMA_URL, MODEL, 'hello world')
+
+    expect(result).toEqual(MOCK_EMBEDDING)
+  })
+
+  test('should throw on non-OK response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('model not found'),
+      }),
+    )
+
+    await expect(generateEmbedding(OLLAMA_URL, MODEL, 'hello')).rejects.toThrow(
+      'Ollama embedding failed (500 Internal Server Error): model not found',
+    )
+  })
+
+  test('should throw on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+
+    await expect(generateEmbedding(OLLAMA_URL, MODEL, 'hello')).rejects.toThrow(
+      'Failed to connect to Ollama at http://localhost:11434: ECONNREFUSED',
+    )
+  })
+
+  test('should pass ollamaUrl and model as provided', async () => {
+    const customUrl = 'http://ollama:8080'
+    const customModel = 'mxbai-embed-large'
+
+    await generateEmbedding(customUrl, customModel, 'test')
+
+    expect(fetch).toHaveBeenCalledWith(`${customUrl}/api/embed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: customModel, input: 'test' }),
+    })
+  })
+})

--- a/packages/server/src/services/embedding/generate-embedding.ts
+++ b/packages/server/src/services/embedding/generate-embedding.ts
@@ -1,0 +1,39 @@
+/**
+ * Generates a vector embedding for the given text using the Ollama API.
+ *
+ * Calls the Ollama `/api/embed` endpoint with native `fetch`. Returns the
+ * embedding as a `number[]`. Wraps errors with descriptive messages.
+ *
+ * @param ollamaUrl - Base URL of the Ollama server (e.g. `http://localhost:11434`)
+ * @param model - Embedding model name (e.g. `nomic-embed-text`)
+ * @param text - Text to generate an embedding for
+ * @returns The embedding vector as an array of numbers
+ */
+export const generateEmbedding = async (
+  ollamaUrl: string,
+  model: string,
+  text: string,
+): Promise<number[]> => {
+  let response: Response
+
+  try {
+    response = await fetch(`${ollamaUrl}/api/embed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, input: text }),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to connect to Ollama at ${ollamaUrl}: ${message}`)
+  }
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(
+      `Ollama embedding failed (${response.status} ${response.statusText}): ${body}`,
+    )
+  }
+
+  const data = (await response.json()) as { embeddings: number[][] }
+  return data.embeddings[0]
+}

--- a/packages/server/src/services/embedding/index.ts
+++ b/packages/server/src/services/embedding/index.ts
@@ -1,0 +1,1 @@
+export { generateEmbedding } from './generate-embedding.js'


### PR DESCRIPTION
Closes #12

## Summary

Adds the `generateEmbedding` function that calls the Ollama `/api/embed` endpoint to produce vector embeddings. Uses native `fetch`, follows DI pattern (URL and model as parameters), and wraps errors with descriptive messages.

## Changes

- `packages/server/src/services/embedding/generate-embedding.ts` (new) — `generateEmbedding(ollamaUrl, model, text)` function
- `packages/server/src/services/embedding/generate-embedding.test.ts` (new) — 5 tests covering happy path, error responses, and network failures
- `packages/server/src/services/embedding/index.ts` (new) — barrel re-export

## Test Coverage

5 tests:
- Correct POST request to `/api/embed` with model and input
- Returns embedding vector from response
- Throws descriptive error on non-OK HTTP response
- Throws descriptive error on network failure (ECONNREFUSED)
- Custom ollamaUrl and model are passed through correctly

## Checklist

- [x] Tests pass (`npm run test:run`)
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports