### PR TITLE
feat: add grammY bot factory and auth middleware

### DIFF
--- a/packages/server/src/bot/create-bot.test.ts
+++ b/packages/server/src/bot/create-bot.test.ts
@@ -1,0 +1,37 @@
+import { Bot } from 'grammy'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createBot } from './create-bot.js'
+
+vi.mock('grammy', () => {
+  const BotMock = vi.fn().mockImplementation(() => ({
+    use: vi.fn(),
+  }))
+  return { Bot: BotMock }
+})
+
+describe('createBot', () => {
+  beforeEach(() => {
+    vi.mocked(Bot).mockClear()
+  })
+
+  test('should create a Bot instance with the given token', () => {
+    createBot('test-token', ['123'])
+
+    expect(Bot).toHaveBeenCalledWith('test-token')
+  })
+
+  test('should return the bot instance', () => {
+    const bot = createBot('test-token', ['123'])
+
+    expect(bot).toBeDefined()
+    expect(bot.use).toBeDefined()
+  })
+
+  test('should install auth middleware on the bot', () => {
+    const bot = createBot('test-token', ['123', '456'])
+
+    expect(bot.use).toHaveBeenCalledOnce()
+    expect(bot.use).toHaveBeenCalledWith(expect.any(Function))
+  })
+})

--- a/packages/server/src/bot/create-bot.ts
+++ b/packages/server/src/bot/create-bot.ts
@@ -1,0 +1,22 @@
+import { Bot } from 'grammy'
+
+import { createAuthMiddleware } from './middleware/auth.js'
+
+/**
+ * Creates and configures a grammY Bot instance with auth middleware.
+ *
+ * The bot is configured with an auth middleware that restricts access to the
+ * given list of Telegram user IDs. Long polling is used for development;
+ * webhook support is deferred to Phase 9 (deployment).
+ *
+ * @param token - Telegram bot token
+ * @param allowedUserIds - Array of allowed Telegram user IDs as strings
+ * @returns A configured grammY Bot instance
+ */
+export const createBot = (token: string, allowedUserIds: string[]) => {
+  const bot = new Bot(token)
+
+  bot.use(createAuthMiddleware(allowedUserIds))
+
+  return bot
+}

--- a/packages/server/src/bot/index.ts
+++ b/packages/server/src/bot/index.ts
@@ -1,0 +1,2 @@
+export { createBot } from './create-bot.js'
+export { createAuthMiddleware } from './middleware/auth.js'

--- a/packages/server/src/bot/middleware/auth.test.ts
+++ b/packages/server/src/bot/middleware/auth.test.ts
@@ -1,0 +1,61 @@
+import type { Context } from 'grammy'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createAuthMiddleware } from './auth.js'
+
+const createMockCtx = (userId?: number) =>
+  ({
+    from: userId !== undefined ? { id: userId } : undefined,
+    reply: vi.fn(),
+  }) as unknown as Context & { reply: ReturnType<typeof vi.fn> }
+
+describe('createAuthMiddleware', () => {
+  const allowedUserIds = ['123', '456']
+  const middleware = createAuthMiddleware(allowedUserIds)
+
+  test('should call next for allowed user IDs', async () => {
+    const ctx = createMockCtx(123)
+    const next = vi.fn()
+
+    await middleware(ctx, next)
+
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  test('should not reply to allowed users', async () => {
+    const ctx = createMockCtx(456)
+    const next = vi.fn()
+
+    await middleware(ctx, next)
+
+    expect(ctx.reply).not.toHaveBeenCalled()
+  })
+
+  test('should reject non-whitelisted user IDs', async () => {
+    const ctx = createMockCtx(789)
+    const next = vi.fn()
+
+    await middleware(ctx, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(ctx.reply).toHaveBeenCalledWith('Not authorized.')
+  })
+
+  test('should reject when from is undefined', async () => {
+    const ctx = createMockCtx()
+    const next = vi.fn()
+
+    await middleware(ctx, next)
+
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  test('should not reply when from is undefined', async () => {
+    const ctx = createMockCtx()
+    const next = vi.fn()
+
+    await middleware(ctx, next)
+
+    expect(ctx.reply).not.toHaveBeenCalled()
+  })
+})

--- a/packages/server/src/bot/middleware/auth.ts
+++ b/packages/server/src/bot/middleware/auth.ts
@@ -1,0 +1,31 @@
+import type { Context, MiddlewareFn } from 'grammy'
+
+/**
+ * Creates auth middleware that restricts bot access to whitelisted Telegram user IDs.
+ *
+ * Compares the incoming update's user ID against the allowed list. Unauthorized
+ * users receive a "Not authorized." reply. Updates without a `from` field
+ * (e.g. channel posts) are silently dropped.
+ *
+ * @param allowedUserIds - Array of allowed Telegram user IDs as strings
+ * @returns grammY middleware function
+ */
+export const createAuthMiddleware = (
+  allowedUserIds: string[],
+): MiddlewareFn<Context> => {
+  const allowedSet = new Set(allowedUserIds.map(Number))
+
+  return async (ctx, next) => {
+    const userId = ctx.from?.id
+    if (userId === undefined) {
+      return
+    }
+
+    if (!allowedSet.has(userId)) {
+      await ctx.reply('Not authorized.')
+      return
+    }
+
+    await next()
+  }
+}


### PR DESCRIPTION
Closes #13

## Summary

Adds the Telegram bot factory function and auth middleware. `createBot(token, allowedUserIds)` creates a grammY Bot instance with auth middleware that restricts access to whitelisted Telegram user IDs. Unauthorized users get "Not authorized." reply; updates without a `from` field are silently dropped.

## Changes

- `packages/server/src/bot/middleware/auth.ts` (new) — `createAuthMiddleware(allowedUserIds)` using a Set for O(1) lookup
- `packages/server/src/bot/middleware/auth.test.ts` (new) — 5 tests: allow, reject, undefined from
- `packages/server/src/bot/create-bot.ts` (new) — `createBot(token, allowedUserIds)` factory
- `packages/server/src/bot/create-bot.test.ts` (new) — 3 tests: token, instance, middleware installed
- `packages/server/src/bot/index.ts` (new) — barrel re-exports

## Test Coverage

8 tests:
- Auth middleware allows whitelisted user IDs
- Auth middleware does not reply to allowed users
- Auth middleware rejects non-whitelisted user IDs with "Not authorized."
- Auth middleware rejects when `from` is undefined (no reply)
- Auth middleware does not reply when `from` is undefined
- Bot factory creates instance with correct token
- Bot factory returns a bot with `use` method
- Bot factory installs auth middleware

## Checklist

- [x] Tests pass (`npm run test:run`)
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports