### PR TITLE
feat: add concurrency-controlled embedding queue

### DIFF
--- a/packages/server/src/services/embedding/embedding-queue.test.ts
+++ b/packages/server/src/services/embedding/embedding-queue.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createEmbeddingQueue } from './embedding-queue.js'
+import { generateEmbedding } from './generate-embedding.js'
+
+vi.mock('../../logging/get-logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('./generate-embedding.js', () => ({
+  generateEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+}))
+
+const MOCK_MEMORY = {
+  id: 'mem-1',
+  content: 'test content',
+  source: 'telegram',
+}
+
+const createMockDb = (
+  opts: {
+    memory?: typeof MOCK_MEMORY | null
+    hasExistingEmbedding?: boolean
+  } = {},
+) => {
+  const memory = opts.memory === undefined ? MOCK_MEMORY : opts.memory
+
+  const mockSelectLimit = vi.fn().mockResolvedValue(memory ? [memory] : [])
+  const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit })
+  const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere })
+  const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom })
+
+  const mockInsertValues = vi.fn().mockImplementation(() => ({
+    then(
+      onFulfilled: (v: unknown) => unknown,
+      onRejected?: (e: unknown) => unknown,
+    ) {
+      return Promise.resolve(undefined).then(onFulfilled, onRejected)
+    },
+    onConflictDoNothing: vi.fn().mockReturnValue({
+      then(
+        onFulfilled: (v: unknown) => unknown,
+        onRejected?: (e: unknown) => unknown,
+      ) {
+        return Promise.resolve(undefined).then(onFulfilled, onRejected)
+      },
+    }),
+  }))
+  const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { select: mockSelect, insert: mockInsert } as any
+}
+
+const DEPS = {
+  ollamaUrl: 'http://localhost:11434',
+  model: 'nomic-embed-text',
+}
+
+describe('createEmbeddingQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(generateEmbedding).mockResolvedValue([0.1, 0.2, 0.3])
+  })
+
+  test('should return enqueue and drain functions', () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    expect(queue.enqueue).toBeTypeOf('function')
+    expect(queue.drain).toBeTypeOf('function')
+  })
+
+  test('should fetch memory, generate embedding, and insert', async () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('mem-1')
+    await queue.drain()
+
+    expect(db.select).toHaveBeenCalled()
+    expect(generateEmbedding).toHaveBeenCalledWith(
+      'http://localhost:11434',
+      'nomic-embed-text',
+      'test content',
+    )
+    expect(db.insert).toHaveBeenCalled()
+  })
+
+  test('should insert embedding with correct values', async () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('mem-1')
+    await queue.drain()
+
+    const [insertValues] = db.insert.mock.results[0].value.values.mock.calls
+    expect(insertValues[0]).toEqual({
+      memoryId: 'mem-1',
+      model: 'nomic-embed-text',
+      embedding: [0.1, 0.2, 0.3],
+    })
+  })
+
+  test('should skip when memory not found', async () => {
+    const db = createMockDb({ memory: null })
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('nonexistent')
+    await queue.drain()
+
+    expect(generateEmbedding).not.toHaveBeenCalled()
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  test('should not throw on generateEmbedding failure', async () => {
+    vi.mocked(generateEmbedding).mockRejectedValueOnce(new Error('Ollama down'))
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('mem-1')
+
+    await expect(queue.drain()).resolves.toBeUndefined()
+  })
+
+  test('should not throw on DB insert failure', async () => {
+    const db = createMockDb()
+    db.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation(() => ({
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          then(
+            _onFulfilled: (v: unknown) => unknown,
+            onRejected?: (e: unknown) => unknown,
+          ) {
+            return Promise.reject(new Error('DB error')).catch(
+              onRejected ?? (() => {}),
+            )
+          },
+        }),
+      })),
+    })
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('mem-1')
+
+    await expect(queue.drain()).resolves.toBeUndefined()
+  })
+
+  test('should process multiple enqueued items', async () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    queue.enqueue('mem-1')
+    queue.enqueue('mem-2')
+    queue.enqueue('mem-3')
+    await queue.drain()
+
+    expect(generateEmbedding).toHaveBeenCalledTimes(3)
+  })
+
+  test('should return immediately from enqueue', () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    const result = queue.enqueue('mem-1')
+
+    expect(result).toBeUndefined()
+  })
+
+  test('should drain with no pending jobs', async () => {
+    const db = createMockDb()
+    const queue = createEmbeddingQueue({ db, ...DEPS })
+
+    await expect(queue.drain()).resolves.toBeUndefined()
+  })
+})

--- a/packages/server/src/services/embedding/embedding-queue.ts
+++ b/packages/server/src/services/embedding/embedding-queue.ts
@@ -1,0 +1,90 @@
+import { eq } from 'drizzle-orm'
+import pLimit from 'p-limit'
+
+import type { Db } from '../../db/client.js'
+import { memories, memoryEmbeddings } from '../../db/schema.js'
+import { getLogger } from '../../logging/get-logger.js'
+import { generateEmbedding } from './generate-embedding.js'
+
+const logger = getLogger(import.meta.url)
+
+/**
+ * Dependencies for creating an embedding queue.
+ */
+export type EmbeddingQueueDeps = {
+  db: Db
+  ollamaUrl: string
+  model: string
+}
+
+/**
+ * Embedding queue with enqueue and drain functions.
+ */
+export type EmbeddingQueue = {
+  enqueue: (memoryId: string) => void
+  drain: () => Promise<void>
+}
+
+const CONCURRENCY = 3
+
+/**
+ * Creates a concurrency-controlled embedding queue.
+ *
+ * Accepts memory IDs via `enqueue`, fetches each memory's content from the DB,
+ * generates an embedding via Ollama, and stores it in `memory_embeddings`.
+ * Concurrency is limited to 3 via `p-limit`. Errors are logged but never
+ * propagated — callers treat enqueue as fire-and-forget.
+ *
+ * @param deps - Database instance, Ollama URL, and model name
+ * @returns Object with `enqueue` (non-blocking) and `drain` (waits for pending jobs)
+ */
+export const createEmbeddingQueue = (
+  deps: EmbeddingQueueDeps,
+): EmbeddingQueue => {
+  const { db, ollamaUrl, model } = deps
+  const limit = pLimit(CONCURRENCY)
+  const pending: Promise<void>[] = []
+
+  const processMemory = async (memoryId: string): Promise<void> => {
+    try {
+      const [memory] = await db
+        .select()
+        .from(memories)
+        .where(eq(memories.id, memoryId))
+        .limit(1)
+
+      if (!memory) {
+        logger.warn('Memory not found for embedding', { memoryId })
+        return
+      }
+
+      const embedding = await generateEmbedding(
+        ollamaUrl,
+        model,
+        memory.content,
+      )
+
+      await db
+        .insert(memoryEmbeddings)
+        .values({ memoryId, model, embedding })
+        .onConflictDoNothing()
+
+      logger.debug('Embedding stored', { memoryId, model })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Failed to process embedding', { memoryId, error: message })
+    }
+  }
+
+  const enqueue = (memoryId: string): void => {
+    const job = limit(() => processMemory(memoryId))
+    pending.push(job)
+  }
+
+  const drain = async (): Promise<void> => {
+    await Promise.all(pending)
+    pending.length = 0
+  }
+
+  return { enqueue, drain }
+}

--- a/packages/server/src/services/embedding/index.ts
+++ b/packages/server/src/services/embedding/index.ts
@@ -1,1 +1,3 @@
+export { createEmbeddingQueue } from './embedding-queue.js'
+export type { EmbeddingQueue, EmbeddingQueueDeps } from './embedding-queue.js'
 export { generateEmbedding } from './generate-embedding.js'


### PR DESCRIPTION
Closes #14

## Summary

Adds `createEmbeddingQueue` — a p-limit (concurrency=3) controlled queue that processes embedding jobs asynchronously. For each enqueued memory ID, it fetches the memory content from DB, generates an embedding via Ollama, and stores it in `memory_embeddings`. Errors are logged but never propagate (fire-and-forget). Uses `onConflictDoNothing` to handle duplicate embeddings gracefully.

## Changes

- `packages/server/src/services/embedding/embedding-queue.ts` (new) — `createEmbeddingQueue(deps)` returning `{ enqueue, drain }`
- `packages/server/src/services/embedding/embedding-queue.test.ts` (new) — 9 tests covering happy path, error handling, edge cases
- `packages/server/src/services/embedding/index.ts` (modify) — added re-exports

## Test Coverage

9 tests:
- Returns enqueue and drain functions
- Fetches memory, generates embedding, and inserts
- Inserts embedding with correct values (memoryId, model, embedding vector)
- Skips when memory not found
- Does not throw on generateEmbedding failure
- Does not throw on DB insert failure
- Processes multiple enqueued items
- Returns immediately from enqueue (non-blocking)
- Drains with no pending jobs

## Checklist

- [x] Tests pass (`npm run test:run`)
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports