### PR TITLE
feat: add message handler orchestrator for telegram bot

### DIFF
--- a/packages/server/src/bot/handlers/index.ts
+++ b/packages/server/src/bot/handlers/index.ts
@@ -1,0 +1,2 @@
+export { registerMessageHandler } from './on-message.js'
+export type { MessageHandlerDeps } from './on-message.js'

--- a/packages/server/src/bot/handlers/on-message.test.ts
+++ b/packages/server/src/bot/handlers/on-message.test.ts
@@ -1,0 +1,180 @@
+import type { Context } from 'grammy'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { storeMemory } from '../../services/memory/store-memory.js'
+import { registerMessageHandler } from './on-message.js'
+
+vi.mock('../../logging/get-logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('../../services/memory/store-memory.js', () => ({
+  storeMemory: vi.fn(),
+}))
+
+const MOCK_MEMORY = {
+  id: 'mem-1',
+  content: 'hello world',
+  source: 'telegram',
+  search: null,
+  category: null,
+  tags: null,
+  metadata: null,
+  sourceDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+}
+
+const createMockCtx = () =>
+  ({
+    message: {
+      message_id: 42,
+      text: 'hello world',
+      date: 1708430400,
+      chat: { id: 123 },
+    },
+    from: { id: 456 },
+    reply: vi.fn(),
+  }) as unknown as Context & { reply: ReturnType<typeof vi.fn> }
+
+const createMockBot = () => ({
+  on: vi.fn(),
+})
+
+const createMockEmbeddingQueue = () => ({
+  enqueue: vi.fn(),
+  drain: vi.fn(),
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockDb = (): any => ({})
+
+describe('registerMessageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: MOCK_MEMORY,
+      deduplicated: false,
+    })
+  })
+
+  test('should register a message:text handler on the bot', () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    expect(bot.on).toHaveBeenCalledWith('message:text', expect.any(Function))
+  })
+
+  test('should call storeMemory with message content and telegram metadata', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(storeMemory).toHaveBeenCalledWith(db, {
+      content: 'hello world',
+      source: 'telegram',
+      externalId: '42',
+      sourceDate: new Date(1708430400 * 1000),
+      metadata: { chatId: 123, userId: 456 },
+    })
+  })
+
+  test('should enqueue embedding after storing memory', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    await handler(createMockCtx())
+
+    expect(embeddingQueue.enqueue).toHaveBeenCalledWith('mem-1')
+  })
+
+  test('should reply "Stored." on success', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Stored.')
+  })
+
+  test('should reply "Already stored." on dedup', async () => {
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: null,
+      deduplicated: true,
+    })
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Already stored.')
+  })
+
+  test('should not enqueue embedding on dedup', async () => {
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: null,
+      deduplicated: true,
+    })
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    await handler(createMockCtx())
+
+    expect(embeddingQueue.enqueue).not.toHaveBeenCalled()
+  })
+
+  test('should reply "Something went wrong." on error', async () => {
+    vi.mocked(storeMemory).mockRejectedValue(new Error('DB down'))
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Something went wrong.')
+  })
+})

--- a/packages/server/src/bot/handlers/on-message.ts
+++ b/packages/server/src/bot/handlers/on-message.ts
@@ -1,0 +1,61 @@
+import type { Bot, Context } from 'grammy'
+
+import type { Db } from '../../db/client.js'
+import { getLogger } from '../../logging/get-logger.js'
+import type { EmbeddingQueue } from '../../services/embedding/index.js'
+import { storeMemory } from '../../services/memory/store-memory.js'
+
+const logger = getLogger(import.meta.url)
+
+/**
+ * Dependencies for the message handler.
+ */
+export type MessageHandlerDeps = {
+  db: Db
+  embeddingQueue: EmbeddingQueue
+}
+
+/**
+ * Registers a message:text handler on the bot that stores incoming messages
+ * as memories and enqueues them for embedding generation.
+ *
+ * @param bot - The grammY bot instance to register the handler on
+ * @param deps - Database instance and embedding queue
+ */
+export const registerMessageHandler = (
+  bot: Pick<Bot, 'on'>,
+  deps: MessageHandlerDeps,
+): void => {
+  const { db, embeddingQueue } = deps
+
+  bot.on('message:text', async (ctx: Context) => {
+    try {
+      const message = ctx.message!
+      const text = message.text!
+      const messageId = String(message.message_id)
+      const sourceDate = new Date(message.date * 1000)
+      const chatId = message.chat.id
+      const userId = ctx.from!.id
+
+      const result = await storeMemory(db, {
+        content: text,
+        source: 'telegram',
+        externalId: messageId,
+        sourceDate,
+        metadata: { chatId, userId },
+      })
+
+      if (result.deduplicated) {
+        await ctx.reply('Already stored.')
+        return
+      }
+
+      embeddingQueue.enqueue(result.data.id)
+      await ctx.reply('Stored.')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Failed to handle message', { error: message })
+      await ctx.reply('Something went wrong.')
+    }
+  })
+}

--- a/packages/server/src/bot/index.ts
+++ b/packages/server/src/bot/index.ts
@@ -1,2 +1,4 @@
 export { createBot } from './create-bot.js'
+export { registerMessageHandler } from './handlers/index.js'
+export type { MessageHandlerDeps } from './handlers/index.js'
 export { createAuthMiddleware } from './middleware/auth.js'


### PR DESCRIPTION
Closes #15

## Summary

Adds the `registerMessageHandler` orchestrator that wires incoming Telegram text messages to the memory storage and embedding pipeline.

## Changes

- `packages/server/src/bot/handlers/on-message.ts` (new) — `registerMessageHandler(bot, deps)` registers a `message:text` handler that stores the message via `storeMemory`, enqueues embedding on success, and replies with status
- `packages/server/src/bot/handlers/on-message.test.ts` (new) — 7 tests covering success, dedup, error handling, and embedding enqueue behavior
- `packages/server/src/bot/handlers/index.ts` (new) — barrel re-exports
- `packages/server/src/bot/index.ts` (modified) — added handler re-exports

## Test Coverage

7 tests:
- Registers message:text handler on bot
- Calls storeMemory with correct telegram metadata (content, source, externalId, sourceDate, chatId, userId)
- Enqueues embedding after storing memory
- Replies "Stored." on success
- Replies "Already stored." on dedup
- Does not enqueue embedding on dedup
- Replies "Something went wrong." on error

## Checklist

- [x] Tests pass (`npm run test:run`)
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports