### PR TITLE
feat: wire bot, queue, and db in application entry point

### DIFF
--- a/packages/server/src/bot/handlers/index.ts
+++ b/packages/server/src/bot/handlers/index.ts
@@ -1,0 +1,2 @@
+export { registerMessageHandler } from './on-message.js'
+export type { MessageHandlerDeps } from './on-message.js'

--- a/packages/server/src/bot/handlers/on-message.test.ts
+++ b/packages/server/src/bot/handlers/on-message.test.ts
@@ -1,0 +1,180 @@
+import type { Context } from 'grammy'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { storeMemory } from '../../services/memory/store-memory.js'
+import { registerMessageHandler } from './on-message.js'
+
+vi.mock('../../logging/get-logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('../../services/memory/store-memory.js', () => ({
+  storeMemory: vi.fn(),
+}))
+
+const MOCK_MEMORY = {
+  id: 'mem-1',
+  content: 'hello world',
+  source: 'telegram',
+  search: null,
+  category: null,
+  tags: null,
+  metadata: null,
+  sourceDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+}
+
+const createMockCtx = () =>
+  ({
+    message: {
+      message_id: 42,
+      text: 'hello world',
+      date: 1708430400,
+      chat: { id: 123 },
+    },
+    from: { id: 456 },
+    reply: vi.fn(),
+  }) as unknown as Context & { reply: ReturnType<typeof vi.fn> }
+
+const createMockBot = () => ({
+  on: vi.fn(),
+})
+
+const createMockEmbeddingQueue = () => ({
+  enqueue: vi.fn(),
+  drain: vi.fn(),
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockDb = (): any => ({})
+
+describe('registerMessageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: MOCK_MEMORY,
+      deduplicated: false,
+    })
+  })
+
+  test('should register a message:text handler on the bot', () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    expect(bot.on).toHaveBeenCalledWith('message:text', expect.any(Function))
+  })
+
+  test('should call storeMemory with message content and telegram metadata', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(storeMemory).toHaveBeenCalledWith(db, {
+      content: 'hello world',
+      source: 'telegram',
+      externalId: '42',
+      sourceDate: new Date(1708430400 * 1000),
+      metadata: { chatId: 123, userId: 456 },
+    })
+  })
+
+  test('should enqueue embedding after storing memory', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    await handler(createMockCtx())
+
+    expect(embeddingQueue.enqueue).toHaveBeenCalledWith('mem-1')
+  })
+
+  test('should reply "Stored." on success', async () => {
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Stored.')
+  })
+
+  test('should reply "Already stored." on dedup', async () => {
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: null,
+      deduplicated: true,
+    })
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Already stored.')
+  })
+
+  test('should not enqueue embedding on dedup', async () => {
+    vi.mocked(storeMemory).mockResolvedValue({
+      data: null,
+      deduplicated: true,
+    })
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    await handler(createMockCtx())
+
+    expect(embeddingQueue.enqueue).not.toHaveBeenCalled()
+  })
+
+  test('should reply "Something went wrong." on error', async () => {
+    vi.mocked(storeMemory).mockRejectedValue(new Error('DB down'))
+    const bot = createMockBot()
+    const db = createMockDb()
+    const embeddingQueue = createMockEmbeddingQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerMessageHandler(bot as any, { db, embeddingQueue })
+
+    const [, handler] = bot.on.mock.calls[0]
+    const ctx = createMockCtx()
+    await handler(ctx)
+
+    expect(ctx.reply).toHaveBeenCalledWith('Something went wrong.')
+  })
+})

--- a/packages/server/src/bot/handlers/on-message.ts
+++ b/packages/server/src/bot/handlers/on-message.ts
@@ -1,0 +1,61 @@
+import type { Bot, Context } from 'grammy'
+
+import type { Db } from '../../db/client.js'
+import { getLogger } from '../../logging/get-logger.js'
+import type { EmbeddingQueue } from '../../services/embedding/index.js'
+import { storeMemory } from '../../services/memory/store-memory.js'
+
+const logger = getLogger(import.meta.url)
+
+/**
+ * Dependencies for the message handler.
+ */
+export type MessageHandlerDeps = {
+  db: Db
+  embeddingQueue: EmbeddingQueue
+}
+
+/**
+ * Registers a message:text handler on the bot that stores incoming messages
+ * as memories and enqueues them for embedding generation.
+ *
+ * @param bot - The grammY bot instance to register the handler on
+ * @param deps - Database instance and embedding queue
+ */
+export const registerMessageHandler = (
+  bot: Pick<Bot, 'on'>,
+  deps: MessageHandlerDeps,
+): void => {
+  const { db, embeddingQueue } = deps
+
+  bot.on('message:text', async (ctx: Context) => {
+    try {
+      const message = ctx.message!
+      const text = message.text!
+      const messageId = String(message.message_id)
+      const sourceDate = new Date(message.date * 1000)
+      const chatId = message.chat.id
+      const userId = ctx.from!.id
+
+      const result = await storeMemory(db, {
+        content: text,
+        source: 'telegram',
+        externalId: messageId,
+        sourceDate,
+        metadata: { chatId, userId },
+      })
+
+      if (result.deduplicated) {
+        await ctx.reply('Already stored.')
+        return
+      }
+
+      embeddingQueue.enqueue(result.data.id)
+      await ctx.reply('Stored.')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Failed to handle message', { error: message })
+      await ctx.reply('Something went wrong.')
+    }
+  })
+}

--- a/packages/server/src/bot/index.ts
+++ b/packages/server/src/bot/index.ts
@@ -1,2 +1,4 @@
 export { createBot } from './create-bot.js'
+export { registerMessageHandler } from './handlers/index.js'
+export type { MessageHandlerDeps } from './handlers/index.js'
 export { createAuthMiddleware } from './middleware/auth.js'

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createApp } from './app.js'
+import { createBot } from './bot/create-bot.js'
+import { registerMessageHandler } from './bot/handlers/on-message.js'
+import { createDb } from './db/client.js'
+import { runMigrations } from './db/migrate.js'
+import { startServer } from './index.js'
+import { createEmbeddingQueue } from './services/embedding/embedding-queue.js'
+
+vi.mock('./logging/get-logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('./env.js', () => ({
+  env: {
+    PORT: '3000',
+    DATABASE_URL: 'postgres://localhost/test',
+    TELEGRAM_BOT_TOKEN: 'test-token',
+    TELEGRAM_ALLOWED_USER_IDS: ['123'],
+    OLLAMA_BASE_URL: 'http://localhost:11434',
+  },
+}))
+
+vi.mock('./db/client.js', () => ({
+  createDb: vi.fn().mockReturnValue({ mock: 'db' }),
+}))
+
+vi.mock('./db/migrate.js', () => ({
+  runMigrations: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('./app.js', () => ({
+  createApp: vi.fn().mockReturnValue({
+    listen: vi.fn((_port: string, cb: () => void) => {
+      cb()
+      return { close: vi.fn() }
+    }),
+  }),
+}))
+
+vi.mock('./bot/create-bot.js', () => ({
+  createBot: vi.fn().mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}))
+
+vi.mock('./bot/handlers/on-message.js', () => ({
+  registerMessageHandler: vi.fn(),
+}))
+
+vi.mock('./services/embedding/embedding-queue.js', () => ({
+  createEmbeddingQueue: vi.fn().mockReturnValue({
+    enqueue: vi.fn(),
+    drain: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+describe('startServer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    process.removeAllListeners('SIGTERM')
+    process.removeAllListeners('SIGINT')
+  })
+
+  test('should create database client', async () => {
+    await startServer()
+
+    expect(createDb).toHaveBeenCalledOnce()
+  })
+
+  test('should run migrations', async () => {
+    await startServer()
+
+    expect(runMigrations).toHaveBeenCalledWith({ mock: 'db' })
+  })
+
+  test('should create embedding queue with correct deps', async () => {
+    await startServer()
+
+    expect(createEmbeddingQueue).toHaveBeenCalledWith({
+      db: { mock: 'db' },
+      ollamaUrl: 'http://localhost:11434',
+      model: 'nomic-embed-text',
+    })
+  })
+
+  test('should create bot with token and allowed user ids', async () => {
+    await startServer()
+
+    expect(createBot).toHaveBeenCalledWith('test-token', ['123'])
+  })
+
+  test('should register message handler on bot', async () => {
+    await startServer()
+
+    const bot = vi.mocked(createBot).mock.results[0].value
+    const embeddingQueue = vi.mocked(createEmbeddingQueue).mock.results[0].value
+
+    expect(registerMessageHandler).toHaveBeenCalledWith(bot, {
+      db: { mock: 'db' },
+      embeddingQueue,
+    })
+  })
+
+  test('should start express on configured port', async () => {
+    await startServer()
+
+    const app = vi.mocked(createApp).mock.results[0].value
+    expect(app.listen).toHaveBeenCalledWith('3000', expect.any(Function))
+  })
+
+  test('should start bot polling', async () => {
+    await startServer()
+
+    const bot = vi.mocked(createBot).mock.results[0].value
+    expect(bot.start).toHaveBeenCalledOnce()
+  })
+
+  test('should initialize services in correct order', async () => {
+    const callOrder: string[] = []
+    vi.mocked(createDb).mockImplementation(() => {
+      callOrder.push('createDb')
+      return { mock: 'db' } as unknown as ReturnType<typeof createDb>
+    })
+    vi.mocked(runMigrations).mockImplementation(async () => {
+      callOrder.push('runMigrations')
+    })
+    vi.mocked(createEmbeddingQueue).mockImplementation(() => {
+      callOrder.push('createEmbeddingQueue')
+      return { enqueue: vi.fn(), drain: vi.fn().mockResolvedValue(undefined) }
+    })
+    vi.mocked(createBot).mockImplementation(() => {
+      callOrder.push('createBot')
+      return { start: vi.fn(), stop: vi.fn() } as unknown as ReturnType<
+        typeof createBot
+      >
+    })
+    vi.mocked(registerMessageHandler).mockImplementation(() => {
+      callOrder.push('registerMessageHandler')
+    })
+
+    await startServer()
+
+    expect(callOrder).toEqual([
+      'createDb',
+      'runMigrations',
+      'createEmbeddingQueue',
+      'createBot',
+      'registerMessageHandler',
+    ])
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,11 +1,54 @@
 import { createApp } from './app.js'
+import { createBot } from './bot/create-bot.js'
+import { registerMessageHandler } from './bot/handlers/on-message.js'
+import { createDb } from './db/client.js'
+import { runMigrations } from './db/migrate.js'
 import { env } from './env.js'
 import { getLogger } from './logging/get-logger.js'
+import { createEmbeddingQueue } from './services/embedding/embedding-queue.js'
 
 const logger = getLogger(import.meta.url)
 
-const app = createApp()
+const EMBEDDING_MODEL = 'nomic-embed-text'
 
-app.listen(env.PORT, () => {
-  logger.info(`Server running on port ${env.PORT}`)
+/**
+ * Starts the server by initializing all services in order:
+ * DB, migrations, embedding queue, bot with message handler, Express, and bot polling.
+ * Registers graceful shutdown handlers for SIGTERM and SIGINT.
+ */
+export const startServer = async (): Promise<void> => {
+  const db = createDb()
+  await runMigrations(db)
+
+  const embeddingQueue = createEmbeddingQueue({
+    db,
+    ollamaUrl: env.OLLAMA_BASE_URL,
+    model: EMBEDDING_MODEL,
+  })
+
+  const bot = createBot(env.TELEGRAM_BOT_TOKEN, env.TELEGRAM_ALLOWED_USER_IDS)
+  registerMessageHandler(bot, { db, embeddingQueue })
+
+  const app = createApp()
+  app.listen(env.PORT, () => {
+    logger.info(`Server running on port ${env.PORT}`)
+  })
+
+  const shutdown = async () => {
+    logger.info('Shutting down...')
+    bot.stop()
+    await embeddingQueue.drain()
+    logger.info('Shutdown complete')
+  }
+
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  bot.start()
+  logger.info('Bot started')
+}
+
+startServer().catch((error: unknown) => {
+  logger.error('Failed to start server', { error })
+  process.exit(1)
 })


### PR DESCRIPTION
Closes #16

## Summary

Refactors `index.ts` into an async `startServer` function that initializes all services in correct order: DB client, migrations, embedding queue, bot with message handler, Express server, and bot polling. Adds graceful shutdown via SIGTERM/SIGINT handlers.

## Changes

- `packages/server/src/index.ts` (modified) — replaced inline startup with `startServer()` that wires all services, registers shutdown handlers
- `packages/server/src/index.test.ts` (new) — 8 tests verifying service initialization order and correct dependency wiring
- Includes cherry-picked message handler files from #15 (required dependency)

## Test Coverage

8 tests:
- Creates database client
- Runs migrations
- Creates embedding queue with correct deps (db, ollamaUrl, model)
- Creates bot with token and allowed user IDs
- Registers message handler on bot with db and embedding queue
- Starts Express on configured port
- Starts bot polling
- Initializes services in correct order (createDb → runMigrations → createEmbeddingQueue → createBot → registerMessageHandler)

## Checklist

- [x] Tests pass (`npm run test:run`) — 61 passing
- [x] Types check (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] TSDoc on all exports
- [x] No classes, no semicolons, single quotes
- [x] .js extensions on relative imports